### PR TITLE
 Quick pull for Julie with ability of all.layers() to work on shapefiles without a CRS

### DIFF
--- a/Maps/combine_shapefile_layers.R
+++ b/Maps/combine_shapefile_layers.R
@@ -19,6 +19,12 @@ all.layers <- function(loc,make.sf = F,make.polys=F)
   for (i in 1:length(lyr)) 
   {
     my.shp[[i]] <- st_read(paste0(loc,"/",lyr[i], ".shp"))
+    # If your shapefile doesn't have a CRS set it to 4326 and print a warning
+    if(is.na(st_crs(my.shp[[i]]))) 
+    {
+      my.shp[[i]] <- my.shp[[i]] %>% st_set_crs(4326) 
+      print("Heads up that your shapefile did not have a CRS set, it was set to EPSG 4326")
+    } 
     # If you want to return the layer as a polygon, should be a multilinesegment or similar.
     if(make.polys == T) 
     {

--- a/Maps/pectinid_projector_sf.R
+++ b/Maps/pectinid_projector_sf.R
@@ -240,6 +240,7 @@ pecjector = function(gg.obj = NULL,area = list(y = c(40,46),x = c(-68,-55),crs =
     #If you didn't set a maximum layer depth then it defaults to -500
     if(is.na(add_layer$bathy[3])) add_layer$bathy[3] <- -500 
     # I need coordinates for the bathy
+    browser()
     bath.box <- st_bbox(b.box)
     if(st_crs(b.box)[1]$epsg != "4326") bath.box <- b.box %>% st_transform(crs=4326) %>% st_bbox() 
     


### PR DESCRIPTION
This is a partial change of Pectinid SF (more to follow later today), and an emergency update of the combine shapefile layers for Julie.  The update makes it so a shapefile without a CRS set works but spits a warning