### PR TITLE
This is the complete update, ignore my last foolishness...

### DIFF
--- a/Maps/Convert_raster_geodatabase_to_raster.R
+++ b/Maps/Convert_raster_geodatabase_to_raster.R
@@ -1,0 +1,27 @@
+# This is a function to convert  an ESRI raster geodatabase
+# to an R raster.
+# Note that you need a 32 bit version of R for this to work...
+# because our version of Arc is 32 bit.  64 bit R would work
+# once we have ArcPro on network.
+# Also note that you need access to an Arc license for this
+# as well, so need to be on DFO network.
+
+# Arguements
+#1: gd.input:     The folder in which the ESRI geodatabase resides, 
+#                   see for example "D:\NAS\Projects\GB_time_area_closure_SPERA\Data\CoML_layers.gdb\sst_avg"
+#                   Note that the sst_avg is not a folder inside this, it is an object in the 
+#                   Geodatabase, it isn't obvious that it is in there without knowing what is
+#                   in the geodatabase.
+#2: raster.output: Where do you want to save your raster.  This should be something like "D:/location/gd.name.RData"
+
+gd.rasters <- function(gd.input, raster.output)
+{
+library(arcgisbinding)
+library(sf)
+library(raster)
+library(stars)
+arc.check_product() 
+raster.layer <- as.raster(arc.raster(arc.open(gd.input)))
+
+save.image(raster.output)
+}

--- a/Maps/centre_of_gravity.R
+++ b/Maps/centre_of_gravity.R
@@ -1,0 +1,35 @@
+# Here's a function to calculate the weighted mean (center of gravity) in 1 or two dimensionas along with the standard deviation
+# Adapted from SDMTools package but just using standard weighted mean and weighted variance calcs... 
+# You only need to specify one of x or y.  This could fairly easily be generalized to be an n-dimensional COG if the need ever arose...
+# Arguements:
+
+## The general mapping inputs if you are just wanting to produce a spatial map without an INLA surface
+
+#1: x     The locations of your data in the 'x' direction, a vector.  missing by default
+#2: y     The locations of the data in the 'y' direction, a vector.  missing by default
+#3: wt    The weigths for your x and y data. In 2-D this assumes your weighting is the same in each direction 
+#           (i.e. think a coordinate with a weighting value associated with it)
+
+
+cog.calc <- function(x,y,wt)
+{
+  if(!missing(x)) 
+  {
+    wt.mean.x <- x * wt
+    cog.x <- sum(wt.mean.x) / sum(wt)
+    sd.x <- sqrt(sum(wt) / (sum(wt)^2 - sum(wt^2) ) * (sum(wt * (x - cog.x)^2)))
+    se.x <-  sd.x/sqrt(length(wt))
+    sum(wt * (wt.mean.x - cog.x)^2)/ (sum(wt))#^2 - sum(wt^2)))#
+    if(missing(y)) return(data.frame(x = cog.x, y = NA,sd.x  = sd.x,sd.y = NA,se.x  = se.x,se.y = NA))
+  }
+  if(!missing(y)) 
+  {
+    wt.mean.y <- y * wt
+    cog.y <- sum(wt.mean.y) / sum(wt)
+    sd.y <- sqrt(sum(wt) / (sum(wt)^2 - sum(wt^2) ) * (sum(wt * (y - cog.y)^2)))
+    se.y <- sd.y /sqrt(length(wt))
+    if(missing(x)) return(data.frame(x = NA, y = cog.y,sd.x  = NA,sd.y = sd.y,se.x  = NA,se.y = se.y))
+  }
+  # This will only happen if both x and y are not missing...
+  return(data.frame(x = cog.x, y = cog.y,sd.x  = sd.x,sd.y  = sd.y,se.x  = se.x,se.y = se.y))
+} # end cog.fun <- function(x,y,wt)

--- a/Maps/pectinid_projector_sf.R
+++ b/Maps/pectinid_projector_sf.R
@@ -3,9 +3,6 @@
 # Major revision to work with sf package undertaken in 2020, DK joined the party in March 2020, attempt to make this more user friendly 
 # removed option add_land (we always want land...)
 
-# Note that we need a couple of cute little functions for this to work.  Be sure to all call "addalpha" , "convert_coords", and "all.layers"
-# Before running this function, but I haven't settled on a directory for them quite yet...
-
 # Arguements:
 
 ## The general mapping inputs if you are just wanting to produce a spatial map without an INLA surface
@@ -19,7 +16,7 @@
 
 #3: plot       Do you want to display the plot.  Default = T.  if plot= F you will just get a ggplot object useful if just making it a baselayer.
 
-#4: repo       The repository from which you will pull the data.  The default is "github" (which has all the main data) 
+#4: repo       The repository from which you will pull the GIS related data.  The default is "github" (which has all the main data) 
 ###               option is to specify the directory you want to pull data from, likely you want to use "Y:/Offshore/Assessment/Data/Maps/approved/GIS_layers"
 
 #5: c_sys      What coordinate system are you using, options are "ll"  which is lat/lon and WGS84 or "utm_zone" which is utm, you put in the zone yourself
@@ -30,7 +27,7 @@
 ###               size of your area
 
 #7: direct_fns  The directory that our local functions reside in, defaults to the ESS directory structure so it pulls in the stable master version of the function
-###               "Y:/Offshore/Assessment/Assesment_fns/"
+###               "Y:/Offshore/Assessment/Assesment_fns/".  If you set to direct_fns = 'github' it will grab the functions from our Mar-Scal repo.
 
 #################################### LAYER OPTIONS#################################### LAYER OPTIONS#################################### LAYER OPTIONS
 
@@ -139,6 +136,7 @@ pecjector = function(gg.obj = NULL,area = list(y = c(40,46),x = c(-68,-55),crs =
   require(pals) || stop("Pals package is needed, it is your one stop shop of colour pallettes in R, install it!")
   require(ggnewscale)  || stop ("Please install ggnewscale...If you want multiple colour ramps on one ggplot, you want ggnewscale :-)")
   require(ggspatial) ||stop ("Please install ggspatial which is needed to include the scale bar")
+  require(RCurl) || stop ("Please install RCurl so yo you can pull functions from github")
   #require(rmapshaper) || stop ("Please install rmapshaper, has a nice means of cleaning up that ugly German survey figure...")
   #require(scales) || stop ("Please install scales, needed to make legend in discrete ggplot not be in scientific notation")
   # If you are using github then we can call in the below 3 functions needed below from github, they aren't in production currently so should work fine
@@ -154,9 +152,24 @@ pecjector = function(gg.obj = NULL,area = list(y = c(40,46),x = c(-68,-55),crs =
   # if(repo == "local")
   # {
   ## always pull from local... these should be in the same location as pectinid_projector, right?  
-  source(paste(direct_fns,"Maps/convert_coords.R",sep="")) 
-  source(paste(direct_fns,"Maps/add_alpha_function.R",sep="")) 
-  source(paste(direct_fns,"Maps/combine_shapefile_layers.R",sep="")) 
+  if(direct_fns != 'github')
+  {
+    source(paste(direct_fns,"Maps/convert_coords.R",sep="")) 
+    source(paste(direct_fns,"Maps/add_alpha_function.R",sep="")) 
+    source(paste(direct_fns,"Maps/combine_shapefile_layers.R",sep="")) 
+  }
+  if(direct_fns == 'github')
+  {
+  #browser()
+    # Download this to the temp directory you created above
+    sc <- getURL("https://raw.githubusercontent.com/Mar-scal/Assessment_fns/master/Maps/convert_coords.R",ssl.verifypeer = FALSE)
+    eval(parse(text = sc))
+    sc <- getURL("https://raw.githubusercontent.com/Mar-scal/Assessment_fns/master/Maps/add_alpha_function.R",ssl.verifypeer = FALSE)
+    eval(parse(text = sc))
+    sc <- getURL("https://raw.githubusercontent.com/Mar-scal/Assessment_fns/master/Maps/combine_shapefile_layers.R",ssl.verifypeer = FALSE)
+    eval(parse(text = sc))  
+  }
+  
   # This is needed to spin the field projection to be oriented how GIS wants them, unclear why it is weird like this!
   rotate <- function(x) t(apply(x, 2, rev)) 
   options(scipen=999)# Avoid scientific notation


### PR DESCRIPTION
This is the main plotly implementation revision to pectinid. Still having various minor issues with colors, but everything appears to be fully functional now. The only thing that changes is there is a plot_as input, it defaults to 'ggplot' so old code should work as always without specfying anything. Also changes to combine_shapefile_layers, know known as combo_shp both the function call the the file name, added option to force the output to be a "MULTILINESTRING". Super minor change to conver_coords which allows a coulpe more options for names when trying to plot all the way to NFLD. Note that at the time of this revision there was a bug in marmap which was causing issues so the bathy extent was hard coded, something we'll want to change back when bug is fixed.